### PR TITLE
Tap Switch driver extended to support FOHSWITCH (Friends of Hue Switch)

### DIFF
--- a/drivers/tap/device.js
+++ b/drivers/tap/device.js
@@ -3,31 +3,56 @@
 const Homey = require('homey');
 const HueDevice = require('../../lib/HueDevice.js');
 
-const BUTTON_EVENT_MAP = {
+const BUTTON_EVENT_MAP_ZGPSWITCH = {
   '34': 'button1',
   '16': 'button2',
   '17': 'button3',
   '18': 'button4',  
 }
 
+const BUTTON_EVENT_MAP_FOHSWITCH = {
+  '20': 'button1',
+  '21': 'button2',
+  '22': 'button3',
+  '23': 'button4',
+};
+
 module.exports = class DeviceTap extends HueDevice {
     
   onPoll({ device }) {   
     super.onPoll(...arguments);
     if(!device.state) return;
+
+    // map hue json values to a variable
+    let lastupdated = device.state.lastupdated;
+    let buttonevent = device.state.buttonevent;
+    let modelid = device.modelid;
+
+    // modelid options: "ZGPSWITCH" (Hue Tap Switch), "FOHSWITCH" (Friends of Hue Switch)
+    let button_event_map;
+    switch (modelid) {
+      case "ZGPSWITCH":
+          button_event_map = BUTTON_EVENT_MAP_ZGPSWITCH;
+          break;
+      case "FOHSWITCH":
+          button_event_map = BUTTON_EVENT_MAP_FOHSWITCH;
+          break;
+      default:
+    }
         
     // Initial load, don't trigger a Flow when the app has just started
     if( typeof this.buttonevent === 'undefined' ) {
-      this.buttonevent = device.state.buttonevent;
-      this.lastupdated = device.state.lastupdated;
+      this.lastupdated = lastupdated;
+      this.buttonevent = buttonevent;
+      this.modelid = modelid;
     } else {
 
       // if last press changed and button is the same
-      if( device.state.lastupdated !== this.lastupdated && device.state.buttonevent === this.buttonevent ) {
+      if( lastupdated !== this.lastupdated && buttonevent === this.buttonevent ) {
         this.lastupdated = device.state.lastupdated;
         
-        const button = BUTTON_EVENT_MAP[device.state.buttonevent];
-        this.log(`Same button pressed [${device.state.buttonevent}]:`, button);
+        const button = button_event_map[buttonevent];
+        this.log(`Same button pressed [${buttonevent}]:`, button);
         
         if( button ) {        
           this.driver.flowCardTriggerTapButtonPressed
@@ -37,12 +62,12 @@ module.exports = class DeviceTap extends HueDevice {
       }
 
       // else if the button has changed
-      else if( this.buttonevent !== device.state.buttonevent ) {
-        this.buttonevent = device.state.buttonevent;
-        this.lastupdated = device.state.lastupdated;
+      else if( this.buttonevent !== buttonevent ) {
+        this.buttonevent = buttonevent;
+        this.lastupdated = lastupdated;
         
-        const button = BUTTON_EVENT_MAP[device.state.buttonevent];
-        this.log(`New button pressed [${device.state.buttonevent}]:`, button);
+        const button = button_event_map[buttonevent];
+        this.log(`New button pressed [${buttonevent}]:`, button);
         
         if( button ) {
           this.driver.flowCardTriggerTapButtonPressed
@@ -54,6 +79,10 @@ module.exports = class DeviceTap extends HueDevice {
     
     // cleanup
     device = null;
+    buttonevent = null;
+    lastupdated = null;
+    modelid = null;
+    button_event_map = null;
   }
   
 }

--- a/drivers/tap/driver.js
+++ b/drivers/tap/driver.js
@@ -14,9 +14,9 @@ module.exports = class DriverTap extends HueDriver {
   }
   
   static onPairListDevice({ bridge, device }) {
-    bridge.log('Tap Device:', device.modelid, device.name);
+    bridge.log('Tap Device:', device.modelid, device.type, device.name);
     
-    if( !['ZGPSWITCH'].includes(device.modelid)) return null;
+    if( !['ZGPSwitch'].includes(device.type)) return null;
     return {};
   }
   


### PR DESCRIPTION
As a dedicated "Friends of Hue Switch" driver (with more features) it was not possible to merge my last PR into the official homey hue app due to the fact that third party devices doesn't seem to be  supported. 
As @WeeJeWel suggested, I've now slightly modified the Tap driver to support as well the Friends of Hue Switch, as it is pretty similar from its function, e.g. same amount of buttons. It looks like I changed a lot in the driver, but that's mostly because I refactored as well the if-statements to detect the button changes (I've added variables instead of always reread the whole path). 

Missing events are:
- holding a button for more than a very short period
- release a button after holding a button